### PR TITLE
fix error: paramiko.ssh_exception.SSHException

### DIFF
--- a/gitlab_tools/tools/crypto.py
+++ b/gitlab_tools/tools/crypto.py
@@ -68,6 +68,7 @@ def get_remote_server_key(ip: str, port: int=22) -> paramiko.pkey.PKey:
     my_socket.connect((ip, port))
 
     my_transport = paramiko.Transport(my_socket)
+    my_transport.banner_timeout = 30
     my_transport.start_client()
     ssh_key = my_transport.get_remote_server_key()
 


### PR DESCRIPTION
error info

``` 
I0325 06:51:12.400 252 _internal.py:97] 172.21.0.1 - - [25/Mar/2019 06:51:12] "POST /fingerprint/fingerprint-check HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/paramiko/transport.py", line 2138, in _check_banner
    buf = self.packetizer.readline(timeout)
  File "/usr/local/lib/python3.5/site-packages/paramiko/packet.py", line 367, in readline
    buf += self._read_timeout(timeout)
  File "/usr/local/lib/python3.5/site-packages/paramiko/packet.py", line 563, in _read_timeout
    raise EOFError()
EOFError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 2309, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 2295, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 1741, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.5/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.5/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python3.5/site-packages/flask_login/utils.py", line 261, in decorated_view
    return func(*args, **kwargs)
  File "/var/app/gitlab-tools/gitlab_tools/views/fingerprint/index.py", line 176, in check_hostname_fingerprint
    return check_fingerprint_hostname(hostname_string)
  File "/var/app/gitlab-tools/gitlab_tools/views/fingerprint/index.py", line 40, in check_fingerprint_hostname
    found, remote_server_key = check_hostname(hostname, known_hosts_path)
  File "/var/app/gitlab-tools/gitlab_tools/tools/fingerprint.py", line 22, in check_hostname
    remote_server_key = get_remote_server_key(hostname)
  File "/var/app/gitlab-tools/gitlab_tools/tools/crypto.py", line 71, in get_remote_server_key
    my_transport.start_client()
  File "/usr/local/lib/python3.5/site-packages/paramiko/transport.py", line 587, in start_client
    raise e
  File "/usr/local/lib/python3.5/site-packages/paramiko/transport.py", line 1966, in run
    self._check_banner()
  File "/usr/local/lib/python3.5/site-packages/paramiko/transport.py", line 2143, in _check_banner
    "Error reading SSH protocol banner" + str(e)
paramiko.ssh_exception.SSHException: Error reading SSH protocol banner

```