### PR TITLE
fix(db): update online migrations

### DIFF
--- a/gitlab_tools/migrations/env.py
+++ b/gitlab_tools/migrations/env.py
@@ -73,7 +73,6 @@ def run_migrations_online():
     connection = engine.connect()
     context.configure(connection=connection,
                       target_metadata=target_metadata,
-                      compare_type=True,
                       process_revision_directives=process_revision_directives,
                       **current_app.extensions['migrate'].configure_args)
 


### PR DESCRIPTION
Hello again @Salamek,

I have tried to upgrade the version of the docker container that I created out of your application as you are aware of at [here](https://github.com/cenk1cenk2/docker-gitlab-tools).

I encountered a problem while trying to run the migrations manually with `manage.py db migrate` and `manage.py db stamp` as you have described.

As it turns out while running the online migrations while trying to configure `alembic.context`, `compare_types` is defined twice as an argument, one explicitly and one I think from `current_app.extensions['migrate'].configure_args` and it was causing a panic .

Therefore, I would submit this PR for your review if it has no destructive changes, this change fixes the flow of the container, elsewise I can adapt it accordingly.